### PR TITLE
fix(universal): get method should take parsed options instead of string

### DIFF
--- a/modules/universal/server/src/platform/node_xhr_impl.ts
+++ b/modules/universal/server/src/platform/node_xhr_impl.ts
@@ -9,7 +9,7 @@ export class NodeXHRImpl extends XHR {
     let completer: PromiseCompleter<string> = PromiseWrapper.completer(),
       parsedUrl = url.parse(templateUrl);
 
-    http.get(templateUrl, (res) => {
+    http.get(parsedUrl, (res) => {
       res.setEncoding('utf8');
 
       // normalize IE9 bug (http://bugs.jquery.com/ticket/1450)


### PR DESCRIPTION
When trying to use templateUrl in component, server throws exceptions. That's because http method receives path string instead of json options and therefore hostname in request is undefined